### PR TITLE
CCSMB-1: Propose Semantic Line Breaks

### DIFF
--- a/Standards/CCSMB-1.md
+++ b/Standards/CCSMB-1.md
@@ -30,6 +30,10 @@ To prevent commit spam, the "last updated" field should only be inserted before 
 
 The version field should only be inserted immediately before the PR is merged.
 
+## Formatting
+
+Each RFC should be written in GitHub-flavoured Markdown and should follow the [Semantic Linebreaks (SemBr)](https://sembr.org) specification.
+
 ## Tone
 
 The RFC should be written in a professional tone. Readers are expected to have a basic understanding of programming jargon and Lua programming.

--- a/Standards/CCSMB-1.md
+++ b/Standards/CCSMB-1.md
@@ -20,7 +20,9 @@ Each RFC should have the following immediately after the title:
 
 ```md
 *Author: Your Name <@yourgithub>*
+
 *Version: v1.0.0
+
 *Last updated: YYYY-MM-DD*
 ```
 


### PR DESCRIPTION
Semantic Line Breaks (https://sembr.org) are a way of indenting Markdown and other markup languages.