### PR TITLE
CCSMB-10: Specifying where programs and libraries are installed and where user data is stored

### DIFF
--- a/Standards/CCSMB-10.md
+++ b/Standards/CCSMB-10.md
@@ -12,3 +12,4 @@ Compliant programs MUST store user data into the directory specified through the
 If the program, library or user data is multiple files, the files MUST be put in a subdirectory.
 
 The settings paths MUST start with a / and MUST NOT end with a /
+If any of the settings are not set then the installers SHOULD prompt the user to set them and programs SHOULD NOT run

--- a/Standards/CCSMB-10.md
+++ b/Standards/CCSMB-10.md
@@ -5,6 +5,7 @@
 *Last updated: YYYY-MM-DD*  
 
 ## `settings` API settings
+
 Compliant installers MUST install programs into the directory specified through the `path.programs` setting and MUST install libraries into the directory specified through the `path.libraries` setting.  
 Compliant programs MUST store user data into the directory specified through the `path.data` setting.
 

--- a/Standards/CCSMB-10.md
+++ b/Standards/CCSMB-10.md
@@ -1,14 +1,11 @@
-# *CCSMB 10:* Specifying where programs and libraries are installed and where user data is stored
+# *CCSMB 10:* Program and library install directories 
 
 *Author: @Rainb0wSkeppy*  
 *Version: vX.Y.Z*  
 *Last updated: YYYY-MM-DD*  
 
 ## `settings` API settings
-Compliant installers MUST install programs into the directory specified through the `path.programs` setting and MUST install libraries into the directory specified through the `path.libraries` setting.
-The installers SHOULD NOT run if the settings aren't set.  
-If the program or library is multiple files, the files MUST be installed in a subdirectory.
-
+Compliant installers MUST install programs into the directory specified through the `path.programs` setting and MUST install libraries into the directory specified through the `path.libraries` setting.  
 Compliant programs MUST store user data into the directory specified through the `path.data` setting.
-The programs SHOULD NOT run if the setting isn't set.
-If the user data is stored in multiple files, the files MUST be stored in a subdirectory.
+
+If the program, library or user data is multiple files, the files MUST be put in a subdirectory.

--- a/Standards/CCSMB-10.md
+++ b/Standards/CCSMB-10.md
@@ -9,7 +9,8 @@
 Compliant installers MUST install programs into the directory specified through the `path.programs` setting and MUST install libraries into the directory specified through the `path.libraries` setting.  
 Compliant programs MUST store user data into the directory specified through the `path.data` setting.
 
-If the program, library or user data is multiple files, the files MUST be put in a subdirectory.
+If the library or user data is multiple files, the files MUST be put in a subdirectory.
+If the program is multiple files, the files MUST be put in a subdirectory and there MUST be a file named the same as the directory but with a .lua extension.
 
 The settings paths MUST start with a / and MUST NOT end with a /
 If any of the settings are not set then the installers SHOULD prompt the user to set them and programs SHOULD NOT run

--- a/Standards/CCSMB-10.md
+++ b/Standards/CCSMB-10.md
@@ -10,3 +10,5 @@ Compliant installers MUST install programs into the directory specified through 
 Compliant programs MUST store user data into the directory specified through the `path.data` setting.
 
 If the program, library or user data is multiple files, the files MUST be put in a subdirectory.
+
+The settings paths MUST start with a / and MUST NOT end with a /

--- a/Standards/CCSMB-10.md
+++ b/Standards/CCSMB-10.md
@@ -1,0 +1,14 @@
+# *CCSMB 10:* Specifying where programs and libraries are installed and where user data is stored
+
+*Author: @Rainb0wSkeppy*  
+*Version: vX.Y.Z*  
+*Last updated: YYYY-MM-DD*  
+
+## `settings` API settings
+Compliant installers MUST install programs into the directory specified through the `path.programs` setting and MUST install libraries into the directory specified through the `path.libraries` setting.
+The installers SHOULD NOT run if the settings aren't set.  
+If the program or library is multiple files, the files MUST be installed in a subdirectory.
+
+Compliant programs MUST store user data into the directory specified through the `path.data` setting.
+The programs SHOULD NOT run if the setting isn't set.
+If the user data is stored in multiple files, the files MUST be stored in a subdirectory.


### PR DESCRIPTION
Because a lot of programs install all of their files and dependencies in the root directory.